### PR TITLE
Optimize keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   },
   "homepage": "https://github.com/0m4r/MMM-SoccerLiveScore#readme",
   "keywords": [
-    "MMM",
     "magic mirror",
     "magic mirror 2",
     "live score",
-    "soccer"
+    "soccer",
+    "sport"
   ],
   "devDependencies": {
     "eslint": "^8.56.0",


### PR DESCRIPTION
On [the new module list ](https://kristjanesperanto.github.io/MagicMirror-3rd-Party-Modules/) we are using `sport` like a main category. So it would be nice if sport modules use it as keyword.